### PR TITLE
Remove reverse domain style from plugin id.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	id="com.danielsogl.cordova.backgroundaudio"
+	id="cordova-plugin-background-audio"
 	version="1.0.0">
 
 	<name>background-audio</name>


### PR DESCRIPTION
Most recent Cordova Plugins follow the "npm style" naming convention, instead of the reverse domain style names. (https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#plugin)

I believe the reverse domain structure also leads to some weird entries being added to config.xml and package.json which then reference a plugin which isn't published (in this case `com.danielsogl.cordova.backgroundaudio`).

This should address that.