### PR TITLE
Adds an option to pass no options to the background audio 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ see [#9](/../../issues/9)
 Add the following to your `config.xml`
 
     <gap:plugin name="cordova-plugin-background-audio" />
+
+# Compatibility with Cordova-Plugin-Music-Controls
+
+If you're using the `cordova-plugin-music-controls` plugin, you'll need to specify the following preference or your Music Controls will not work when using Cordova Audio:
+
+```xml
+<preference name="UsesMediaControls" value="true" />
+```

--- a/src/ios/BackgroundAudio.m
+++ b/src/ios/BackgroundAudio.m
@@ -8,13 +8,13 @@
 @implementation BackgroundAudio
 
 - (void)pluginInitialize {
-    BOOL usesMusicControls = [self.commandDelegate.settings objectForKey:[@"usesMusicControls" lowercaseString]];
+    BOOL usesMediaControls = [self.commandDelegate.settings objectForKey:[@"usesMediaControls" lowercaseString]];
     // initializations go here.
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     BOOL ok;
     NSError *setCategoryError = nil;
 
-    if (usesMusicControls) {
+    if (usesMediaControls) {
         ok = [audioSession setCategory:AVAudioSessionCategoryPlayback
                 withOptions:0
                 error:&setCategoryError];

--- a/src/ios/BackgroundAudio.m
+++ b/src/ios/BackgroundAudio.m
@@ -8,13 +8,23 @@
 @implementation BackgroundAudio
 
 - (void)pluginInitialize {
+    BOOL usesMusicControls = [self.commandDelegate.settings objectForKey:[@"usesMusicControls" lowercaseString]];
     // initializations go here.
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     BOOL ok;
     NSError *setCategoryError = nil;
-    ok = [audioSession setCategory:AVAudioSessionCategoryPlayback
-                       withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                             error:&setCategoryError];
+
+    if (usesMusicControls) {
+        ok = [audioSession setCategory:AVAudioSessionCategoryPlayback
+                withOptions:0
+                error:&setCategoryError];
+    } else {
+        ok = [audioSession setCategory:AVAudioSessionCategoryPlayback
+                withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                error:&setCategoryError];
+    }
+
+    
     if (!ok) {
         NSLog(@"%s setCategoryError=%@", __PRETTY_FUNCTION__, setCategoryError);
     }


### PR DESCRIPTION
...so that it will work with cordova-plugin-media-controls along with CordovaAudio.

# Problem

I want to be able to use  https://github.com/homerours/cordova-music-controls-plugin to be able to control playing audio, however - the `withOptions:AVAudioSessionCategoryOptionMixWithOthers` setting is incompatible with the `MPNowPlayingInfoCenter`.

This adds a param you can set which will allow you to disable the MixWithOthers setting if you're wanting to control media via the `MPNowPlayingInfoCenter`.

References:
https://stackoverflow.com/a/35987525/570006
https://github.com/Telerik-Verified-Plugins/WKWebView/issues/203#issuecomment-196291084